### PR TITLE
feat(tickets): allow ticket creation by using ref

### DIFF
--- a/definition/tickets.yaml
+++ b/definition/tickets.yaml
@@ -84,6 +84,29 @@ paths:
       responses:
         "204": { description: "successful operation" }
       security: [ { roles: [ "ticket:write" ] } ]
+  
+  /tickets/byref:
+    post:
+      tags: [ "tickets" ]
+      summary: "Create a new tickets with references to Playbooks and Template"
+      operationId: "createTicketByRef"
+      parameters:
+        - { name: "ticket", in: "body", description: "New ticket by reference", required: true, schema: { $ref: "#/definitions/TicketFormByRef" }, x-example: { id: 123, owner: bob, name: "Wannacry infection", status: "open", type: "incident" } }
+      responses:
+        "200":
+          description: "successful operation"
+          schema: { $ref: "#/definitions/TicketResponse" }
+          examples:
+            test:
+              id: 123
+              name: "Wannacry infection"
+              type: "incident"
+              status: "open"
+              created: "2021-12-12T12:12:12.000000012Z"
+              modified: "2021-12-12T12:12:12.000000012Z"
+              owner: "bob"
+              schema: "\"\""
+      security: [ { roles: [ "ticket:write" ] } ]
 
   /tickets/{id}:
     get:
@@ -957,6 +980,32 @@ definitions:
       created: { type: string, format: "date-time", example: "1985-04-12T23:20:50.52Z" }
       modified: { type: string, format: "date-time", example: "1985-04-12T23:20:50.52Z" }
 
+  TicketFormByRef:
+    type: object
+    required: [ name, type, status ]
+    properties:
+      id: { type: integer, format: int64, example: 123 }
+      name: { type: string, example: WannyCry }
+      type: { type: string, example: incident }
+      status: { type: string, example: "open" }
+
+      owner: { type: string, example: "bob" }
+      write: { type: array, items: { type: string }, example: [ "alice" ] }
+      read: { type: array, items: { type: string }, example: [ "bob" ] }
+
+      schema_id: { type: string, example: "default" }
+      details: { type: object, example: { "description": "my little incident" } }
+
+      references: { type: array, items: { $ref: '#/definitions/Reference' } }
+      playbooks_id: { type: array, items: { type: string }, example: [ "simple" ] }
+      files: { type: array, items: { $ref: '#/definitions/File' } }
+      comments: { type: array, items: { $ref: '#/definitions/Comment' } }
+      artifacts: { type: array, items: { $ref: "#/definitions/Artifact" } }
+
+      created: { type: string, format: "date-time", example: "1985-04-12T23:20:50.52Z" }
+      modified: { type: string, format: "date-time", example: "1985-04-12T23:20:50.52Z" }
+
+  
   Ticket:
     type: object
     required: [ name, type, status, created, modified, schema ]

--- a/definition/tickets.yaml
+++ b/definition/tickets.yaml
@@ -105,7 +105,7 @@ paths:
               created: "2021-12-12T12:12:12.000000012Z"
               modified: "2021-12-12T12:12:12.000000012Z"
               owner: "bob"
-              schema: "\"\""
+              schema: "{}"
       security: [ { roles: [ "ticket:write" ] } ]
 
   /tickets/{id}:

--- a/generate.sh
+++ b/generate.sh
@@ -23,7 +23,7 @@ mv generated/openapi.json generated/catalyst.json
 echo generate server and tests
 swagger-go-chi generated/community.yml generated
 rm -rf generated/auth generated/cli
-find generated -type f -name "*.go" -print0 | xargs -0 sed -i '' -e 's#"github.com/go-chi/chi"#"github.com/go-chi/chi/v5"#g'
+find generated -type f -name "*.go" -print0 | xargs -0 sed -i'' -e 's#"github.com/go-chi/chi"#"github.com/go-chi/chi/v5"#g'
 
 echo generate typescript client
 openapi-generator generate -i generated/catalyst.yml -o ui/src/client -g typescript-axios --artifact-version 1.0.0-SNAPSHOT

--- a/generated/api/api.go
+++ b/generated/api/api.go
@@ -97,6 +97,26 @@ func parseQueryBoolArray(r *http.Request, key string) ([]bool, error) {
 	return boolArray, nil
 }
 
+func parseQueryOptionalBool(r *http.Request, key string) (*bool, error) {
+	if exists := r.URL.Query().Has(key); exists {
+		var value bool
+		v := r.URL.Query().Get(key)
+		if v == "" {
+			value = true
+			return &value, nil
+		}
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, err})
+		} else {
+			value = b
+			return &value, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func parseQueryOptionalInt(r *http.Request, key string) (*int, error) {
 	s := r.URL.Query().Get(key)
 	if s == "" {

--- a/generated/api/test_api.go
+++ b/generated/api/test_api.go
@@ -17,7 +17,6 @@ var Tests = []struct {
 	Args Args
 	Want Want
 }{
-
 	{
 		Name: "ListAutomations",
 		Args: Args{Method: "Get", URL: "/automations"},
@@ -347,7 +346,7 @@ var Tests = []struct {
 		Args: Args{Method: "Post", URL: "/tickets/byref", Data: map[string]any{"id": 123, "name": "Wannacry infection", "owner": "bob", "status": "open", "type": "incident"}},
 		Want: Want{
 			Status: 200,
-			Body:   map[string]any{"created": time.Date(2021, time.December, 12, 12, 12, 12, 12, time.UTC), "id": 123, "modified": time.Date(2021, time.December, 12, 12, 12, 12, 12, time.UTC), "name": "Wannacry infection", "owner": "bob", "schema": "\"\"", "status": "open", "type": "incident"},
+			Body:   map[string]any{"created": time.Date(2021, time.December, 12, 12, 12, 12, 12, time.UTC), "id": 123, "modified": time.Date(2021, time.December, 12, 12, 12, 12, 12, time.UTC), "name": "Wannacry infection", "owner": "bob", "schema": "{}", "status": "open", "type": "incident"},
 		},
 	},
 

--- a/generated/api/test_api.go
+++ b/generated/api/test_api.go
@@ -343,6 +343,15 @@ var Tests = []struct {
 	},
 
 	{
+		Name: "CreateTicketByRef",
+		Args: Args{Method: "Post", URL: "/tickets/byref", Data: map[string]any{"id": 123, "name": "Wannacry infection", "owner": "bob", "status": "open", "type": "incident"}},
+		Want: Want{
+			Status: 200,
+			Body:   map[string]any{"created": time.Date(2021, time.December, 12, 12, 12, 12, 12, time.UTC), "id": 123, "modified": time.Date(2021, time.December, 12, 12, 12, 12, 12, time.UTC), "name": "Wannacry infection", "owner": "bob", "schema": "\"\"", "status": "open", "type": "incident"},
+		},
+	},
+
+	{
 		Name: "GetTicket",
 		Args: Args{Method: "Get", URL: "/tickets/8125"},
 		Want: Want{

--- a/generated/catalyst.json
+++ b/generated/catalyst.json
@@ -5018,7 +5018,7 @@
                   "modified" : "2021-10-02T16:04:59.078+00:00",
                   "name" : "Wannacry infection",
                   "owner" : "bob",
-                  "schema" : "\"\"",
+                  "schema" : "{}",
                   "status" : "open",
                   "type" : "incident"
                 }

--- a/generated/catalyst.json
+++ b/generated/catalyst.json
@@ -4989,6 +4989,52 @@
         "x-codegen-request-body-name" : "ticket"
       }
     },
+    "/tickets/byref" : {
+      "post" : {
+        "operationId" : "createTicketByRef",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TicketFormByRef"
+              }
+            }
+          },
+          "description" : "New ticket by reference",
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TicketResponse"
+                }
+              },
+              "test" : {
+                "example" : {
+                  "created" : "2021-10-02T16:04:59.078+00:00",
+                  "id" : 123,
+                  "modified" : "2021-10-02T16:04:59.078+00:00",
+                  "name" : "Wannacry infection",
+                  "owner" : "bob",
+                  "schema" : "\"\"",
+                  "status" : "open",
+                  "type" : "incident"
+                }
+              }
+            },
+            "description" : "successful operation"
+          }
+        },
+        "security" : [ {
+          "roles" : [ "ticket:write" ]
+        } ],
+        "summary" : "Create a new tickets with references to Playbooks and Template",
+        "tags" : [ "tickets" ],
+        "x-codegen-request-body-name" : "ticket"
+      }
+    },
     "/tickettypes" : {
       "get" : {
         "operationId" : "listTicketTypes",
@@ -6620,6 +6666,99 @@
           "$ref" : "#/components/schemas/TicketForm"
         },
         "type" : "array"
+      },
+      "TicketFormByRef" : {
+        "properties" : {
+          "artifacts" : {
+            "items" : {
+              "$ref" : "#/components/schemas/Artifact"
+            },
+            "type" : "array"
+          },
+          "comments" : {
+            "items" : {
+              "$ref" : "#/components/schemas/Comment"
+            },
+            "type" : "array"
+          },
+          "created" : {
+            "example" : "1985-04-12T23:20:50.52Z",
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "details" : {
+            "example" : {
+              "description" : "my little incident"
+            },
+            "properties" : { },
+            "type" : "object"
+          },
+          "files" : {
+            "items" : {
+              "$ref" : "#/components/schemas/File"
+            },
+            "type" : "array"
+          },
+          "id" : {
+            "example" : 123,
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "modified" : {
+            "example" : "1985-04-12T23:20:50.52Z",
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "name" : {
+            "example" : "WannyCry",
+            "type" : "string"
+          },
+          "owner" : {
+            "example" : "bob",
+            "type" : "string"
+          },
+          "playbooks_id" : {
+            "example" : [ "simple" ],
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "read" : {
+            "example" : [ "bob" ],
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "references" : {
+            "items" : {
+              "$ref" : "#/components/schemas/Reference"
+            },
+            "type" : "array"
+          },
+          "schema_id" : {
+            "example" : "default",
+            "type" : "string"
+          },
+          "status" : {
+            "example" : "open",
+            "type" : "string"
+          },
+          "type" : {
+            "example" : "incident",
+            "type" : "string"
+          },
+          "write" : {
+            "example" : [ "alice" ],
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "required" : [ "name", "status", "type" ],
+        "type" : "object"
       },
       "TicketList" : {
         "properties" : {

--- a/generated/catalyst.yml
+++ b/generated/catalyst.yml
@@ -895,6 +895,78 @@ definitions:
     items:
       $ref: '#/definitions/TicketForm'
     type: array
+  TicketFormByRef:
+    properties:
+      artifacts:
+        items:
+          $ref: '#/definitions/Artifact'
+        type: array
+      comments:
+        items:
+          $ref: '#/definitions/Comment'
+        type: array
+      created:
+        example: 1985-04-12T23:20:50.52Z
+        format: date-time
+        type: string
+      details:
+        example:
+          description: my little incident
+        type: object
+      files:
+        items:
+          $ref: '#/definitions/File'
+        type: array
+      id:
+        example: 123
+        format: int64
+        type: integer
+      modified:
+        example: 1985-04-12T23:20:50.52Z
+        format: date-time
+        type: string
+      name:
+        example: WannyCry
+        type: string
+      owner:
+        example: bob
+        type: string
+      playbooks_id:
+        example:
+        - simple
+        items:
+          type: string
+        type: array
+      read:
+        example:
+        - bob
+        items:
+          type: string
+        type: array
+      references:
+        items:
+          $ref: '#/definitions/Reference'
+        type: array
+      schema_id:
+        example: default
+        type: string
+      status:
+        example: open
+        type: string
+      type:
+        example: incident
+        type: string
+      write:
+        example:
+        - alice
+        items:
+          type: string
+        type: array
+    required:
+    - name
+    - type
+    - status
+    type: object
   TicketList:
     properties:
       count:
@@ -6944,6 +7016,43 @@ paths:
       - roles:
         - ticket:write
       summary: Create a new tickets in batch
+      tags:
+      - tickets
+  /tickets/byref:
+    post:
+      operationId: createTicketByRef
+      parameters:
+      - description: New ticket by reference
+        in: body
+        name: ticket
+        required: true
+        schema:
+          $ref: '#/definitions/TicketFormByRef'
+        x-example:
+          id: 123
+          name: Wannacry infection
+          owner: bob
+          status: open
+          type: incident
+      responses:
+        "200":
+          description: successful operation
+          examples:
+            test:
+              created: 2021-12-12T12:12:12.000000012Z
+              id: 123
+              modified: 2021-12-12T12:12:12.000000012Z
+              name: Wannacry infection
+              owner: bob
+              schema: '""'
+              status: open
+              type: incident
+          schema:
+            $ref: '#/definitions/TicketResponse'
+      security:
+      - roles:
+        - ticket:write
+      summary: Create a new tickets with references to Playbooks and Template
       tags:
       - tickets
   /tickettypes:

--- a/generated/catalyst.yml
+++ b/generated/catalyst.yml
@@ -7044,7 +7044,7 @@ paths:
               modified: 2021-12-12T12:12:12.000000012Z
               name: Wannacry infection
               owner: bob
-              schema: '""'
+              schema: '{}'
               status: open
               type: incident
           schema:

--- a/generated/community.json
+++ b/generated/community.json
@@ -4559,6 +4559,52 @@
         "x-codegen-request-body-name" : "ticket"
       }
     },
+    "/tickets/byref" : {
+      "post" : {
+        "operationId" : "createTicketByRef",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TicketFormByRef"
+              }
+            }
+          },
+          "description" : "New ticket by reference",
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TicketResponse"
+                }
+              },
+              "test" : {
+                "example" : {
+                  "created" : "2021-10-02T16:04:59.078+00:00",
+                  "id" : 123,
+                  "modified" : "2021-10-02T16:04:59.078+00:00",
+                  "name" : "Wannacry infection",
+                  "owner" : "bob",
+                  "schema" : "\"\"",
+                  "status" : "open",
+                  "type" : "incident"
+                }
+              }
+            },
+            "description" : "successful operation"
+          }
+        },
+        "security" : [ {
+          "roles" : [ "ticket:write" ]
+        } ],
+        "summary" : "Create a new tickets with references to Playbooks and Template",
+        "tags" : [ "tickets" ],
+        "x-codegen-request-body-name" : "ticket"
+      }
+    },
     "/tickettypes" : {
       "get" : {
         "operationId" : "listTicketTypes",
@@ -6041,6 +6087,99 @@
           "$ref" : "#/components/schemas/TicketForm"
         },
         "type" : "array"
+      },
+      "TicketFormByRef" : {
+        "properties" : {
+          "artifacts" : {
+            "items" : {
+              "$ref" : "#/components/schemas/Artifact"
+            },
+            "type" : "array"
+          },
+          "comments" : {
+            "items" : {
+              "$ref" : "#/components/schemas/Comment"
+            },
+            "type" : "array"
+          },
+          "created" : {
+            "example" : "1985-04-12T23:20:50.52Z",
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "details" : {
+            "example" : {
+              "description" : "my little incident"
+            },
+            "properties" : { },
+            "type" : "object"
+          },
+          "files" : {
+            "items" : {
+              "$ref" : "#/components/schemas/File"
+            },
+            "type" : "array"
+          },
+          "id" : {
+            "example" : 123,
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "modified" : {
+            "example" : "1985-04-12T23:20:50.52Z",
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "name" : {
+            "example" : "WannyCry",
+            "type" : "string"
+          },
+          "owner" : {
+            "example" : "bob",
+            "type" : "string"
+          },
+          "playbooks_id" : {
+            "example" : [ "simple" ],
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "read" : {
+            "example" : [ "bob" ],
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "references" : {
+            "items" : {
+              "$ref" : "#/components/schemas/Reference"
+            },
+            "type" : "array"
+          },
+          "schema_id" : {
+            "example" : "default",
+            "type" : "string"
+          },
+          "status" : {
+            "example" : "open",
+            "type" : "string"
+          },
+          "type" : {
+            "example" : "incident",
+            "type" : "string"
+          },
+          "write" : {
+            "example" : [ "alice" ],
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "required" : [ "name", "status", "type" ],
+        "type" : "object"
       },
       "TicketList" : {
         "properties" : {

--- a/generated/community.json
+++ b/generated/community.json
@@ -4588,7 +4588,7 @@
                   "modified" : "2021-10-02T16:04:59.078+00:00",
                   "name" : "Wannacry infection",
                   "owner" : "bob",
-                  "schema" : "\"\"",
+                  "schema" : "{}",
                   "status" : "open",
                   "type" : "incident"
                 }

--- a/generated/community.yml
+++ b/generated/community.yml
@@ -776,6 +776,78 @@ definitions:
     items:
       $ref: '#/definitions/TicketForm'
     type: array
+  TicketFormByRef:
+    properties:
+      artifacts:
+        items:
+          $ref: '#/definitions/Artifact'
+        type: array
+      comments:
+        items:
+          $ref: '#/definitions/Comment'
+        type: array
+      created:
+        example: 1985-04-12T23:20:50.52Z
+        format: date-time
+        type: string
+      details:
+        example:
+          description: my little incident
+        type: object
+      files:
+        items:
+          $ref: '#/definitions/File'
+        type: array
+      id:
+        example: 123
+        format: int64
+        type: integer
+      modified:
+        example: 1985-04-12T23:20:50.52Z
+        format: date-time
+        type: string
+      name:
+        example: WannyCry
+        type: string
+      owner:
+        example: bob
+        type: string
+      playbooks_id:
+        example:
+        - simple
+        items:
+          type: string
+        type: array
+      read:
+        example:
+        - bob
+        items:
+          type: string
+        type: array
+      references:
+        items:
+          $ref: '#/definitions/Reference'
+        type: array
+      schema_id:
+        example: default
+        type: string
+      status:
+        example: open
+        type: string
+      type:
+        example: incident
+        type: string
+      write:
+        example:
+        - alice
+        items:
+          type: string
+        type: array
+    required:
+    - name
+    - type
+    - status
+    type: object
   TicketList:
     properties:
       count:
@@ -6532,6 +6604,43 @@ paths:
       - roles:
         - ticket:write
       summary: Create a new tickets in batch
+      tags:
+      - tickets
+  /tickets/byref:
+    post:
+      operationId: createTicketByRef
+      parameters:
+      - description: New ticket by reference
+        in: body
+        name: ticket
+        required: true
+        schema:
+          $ref: '#/definitions/TicketFormByRef'
+        x-example:
+          id: 123
+          name: Wannacry infection
+          owner: bob
+          status: open
+          type: incident
+      responses:
+        "200":
+          description: successful operation
+          examples:
+            test:
+              created: 2021-12-12T12:12:12.000000012Z
+              id: 123
+              modified: 2021-12-12T12:12:12.000000012Z
+              name: Wannacry infection
+              owner: bob
+              schema: '""'
+              status: open
+              type: incident
+          schema:
+            $ref: '#/definitions/TicketResponse'
+      security:
+      - roles:
+        - ticket:write
+      summary: Create a new tickets with references to Playbooks and Template
       tags:
       - tickets
   /tickettypes:

--- a/generated/community.yml
+++ b/generated/community.yml
@@ -6632,7 +6632,7 @@ paths:
               modified: 2021-12-12T12:12:12.000000012Z
               name: Wannacry infection
               owner: bob
-              schema: '""'
+              schema: '{}'
               status: open
               type: incident
           schema:

--- a/generated/model/model.go
+++ b/generated/model/model.go
@@ -46,6 +46,7 @@ var (
 	TicketSchema                   = new(gojsonschema.Schema)
 	TicketFormSchema               = new(gojsonschema.Schema)
 	TicketFormArraySchema          = new(gojsonschema.Schema)
+	TicketFormByRefSchema          = new(gojsonschema.Schema)
 	TicketListSchema               = new(gojsonschema.Schema)
 	TicketResponseSchema           = new(gojsonschema.Schema)
 	TicketSimpleResponseSchema     = new(gojsonschema.Schema)
@@ -105,6 +106,7 @@ func init() {
 		gojsonschema.NewStringLoader(`{"type":"object","properties":{"artifacts":{"items":{"$ref":"#/definitions/Artifact"},"type":"array"},"comments":{"items":{"$ref":"#/definitions/Comment"},"type":"array"},"created":{"format":"date-time","type":"string"},"details":{"type":"object"},"files":{"items":{"$ref":"#/definitions/File"},"type":"array"},"modified":{"format":"date-time","type":"string"},"name":{"type":"string"},"owner":{"type":"string"},"playbooks":{"type":"object","additionalProperties":{"$ref":"#/definitions/Playbook"}},"read":{"items":{"type":"string"},"type":"array"},"references":{"items":{"$ref":"#/definitions/Reference"},"type":"array"},"schema":{"type":"string"},"status":{"type":"string"},"type":{"type":"string"},"write":{"items":{"type":"string"},"type":"array"}},"required":["name","type","status","created","modified","schema"],"$id":"#/definitions/Ticket"}`),
 		gojsonschema.NewStringLoader(`{"type":"object","properties":{"artifacts":{"items":{"$ref":"#/definitions/Artifact"},"type":"array"},"comments":{"items":{"$ref":"#/definitions/Comment"},"type":"array"},"created":{"format":"date-time","type":"string"},"details":{"type":"object"},"files":{"items":{"$ref":"#/definitions/File"},"type":"array"},"id":{"format":"int64","type":"integer"},"modified":{"format":"date-time","type":"string"},"name":{"type":"string"},"owner":{"type":"string"},"playbooks":{"items":{"$ref":"#/definitions/PlaybookTemplateForm"},"type":"array"},"read":{"items":{"type":"string"},"type":"array"},"references":{"items":{"$ref":"#/definitions/Reference"},"type":"array"},"schema":{"type":"string"},"status":{"type":"string"},"type":{"type":"string"},"write":{"items":{"type":"string"},"type":"array"}},"required":["name","type","status"],"$id":"#/definitions/TicketForm"}`),
 		gojsonschema.NewStringLoader(`{"items":{"$ref":"#/definitions/TicketForm"},"type":"array","$id":"#/definitions/TicketFormArray"}`),
+		gojsonschema.NewStringLoader(`{"type":"object","properties":{"artifacts":{"items":{"$ref":"#/definitions/Artifact"},"type":"array"},"comments":{"items":{"$ref":"#/definitions/Comment"},"type":"array"},"created":{"format":"date-time","type":"string"},"details":{"type":"object"},"files":{"items":{"$ref":"#/definitions/File"},"type":"array"},"id":{"format":"int64","type":"integer"},"modified":{"format":"date-time","type":"string"},"name":{"type":"string"},"owner":{"type":"string"},"playbooks_id":{"items":{"type":"string"},"type":"array"},"read":{"items":{"type":"string"},"type":"array"},"references":{"items":{"$ref":"#/definitions/Reference"},"type":"array"},"schema_id":{"type":"string"},"status":{"type":"string"},"type":{"type":"string"},"write":{"items":{"type":"string"},"type":"array"}},"required":["name","type","status"],"$id":"#/definitions/TicketFormByRef"}`),
 		gojsonschema.NewStringLoader(`{"type":"object","properties":{"count":{"type":"number"},"tickets":{"items":{"$ref":"#/definitions/TicketSimpleResponse"},"type":"array"}},"required":["tickets","count"],"$id":"#/definitions/TicketList"}`),
 		gojsonschema.NewStringLoader(`{"type":"object","properties":{"artifacts":{"items":{"$ref":"#/definitions/Artifact"},"type":"array"},"comments":{"items":{"$ref":"#/definitions/Comment"},"type":"array"},"created":{"format":"date-time","type":"string"},"details":{"type":"object"},"files":{"items":{"$ref":"#/definitions/File"},"type":"array"},"id":{"format":"int64","type":"integer"},"modified":{"format":"date-time","type":"string"},"name":{"type":"string"},"owner":{"type":"string"},"playbooks":{"type":"object","additionalProperties":{"$ref":"#/definitions/PlaybookResponse"}},"read":{"items":{"type":"string"},"type":"array"},"references":{"items":{"$ref":"#/definitions/Reference"},"type":"array"},"schema":{"type":"string"},"status":{"type":"string"},"type":{"type":"string"},"write":{"items":{"type":"string"},"type":"array"}},"required":["id","name","type","status","created","modified","schema"],"$id":"#/definitions/TicketResponse"}`),
 		gojsonschema.NewStringLoader(`{"type":"object","properties":{"artifacts":{"items":{"$ref":"#/definitions/Artifact"},"type":"array"},"comments":{"items":{"$ref":"#/definitions/Comment"},"type":"array"},"created":{"format":"date-time","type":"string"},"details":{"type":"object"},"files":{"items":{"$ref":"#/definitions/File"},"type":"array"},"id":{"format":"int64","type":"integer"},"modified":{"format":"date-time","type":"string"},"name":{"type":"string"},"owner":{"type":"string"},"playbooks":{"type":"object","additionalProperties":{"$ref":"#/definitions/Playbook"}},"read":{"items":{"type":"string"},"type":"array"},"references":{"items":{"$ref":"#/definitions/Reference"},"type":"array"},"schema":{"type":"string"},"status":{"type":"string"},"type":{"type":"string"},"write":{"items":{"type":"string"},"type":"array"}},"required":["id","name","type","status","created","modified","schema"],"$id":"#/definitions/TicketSimpleResponse"}`),
@@ -165,6 +167,7 @@ func init() {
 	TicketSchema = mustCompile(`#/definitions/Ticket`)
 	TicketFormSchema = mustCompile(`#/definitions/TicketForm`)
 	TicketFormArraySchema = mustCompile(`#/definitions/TicketFormArray`)
+	TicketFormByRefSchema = mustCompile(`#/definitions/TicketFormByRef`)
 	TicketListSchema = mustCompile(`#/definitions/TicketList`)
 	TicketResponseSchema = mustCompile(`#/definitions/TicketResponse`)
 	TicketSimpleResponseSchema = mustCompile(`#/definitions/TicketSimpleResponse`)
@@ -469,6 +472,25 @@ type TicketForm struct {
 }
 
 type TicketFormArray []*TicketForm
+
+type TicketFormByRef struct {
+	Artifacts   []*Artifact    `json:"artifacts,omitempty"`
+	Comments    []*Comment     `json:"comments,omitempty"`
+	Created     *time.Time     `json:"created,omitempty"`
+	Details     map[string]any `json:"details,omitempty"`
+	Files       []*File        `json:"files,omitempty"`
+	ID          *int64         `json:"id,omitempty"`
+	Modified    *time.Time     `json:"modified,omitempty"`
+	Name        string         `json:"name"`
+	Owner       *string        `json:"owner,omitempty"`
+	PlaybooksId []string       `json:"playbooks_id,omitempty"`
+	Read        []string       `json:"read,omitempty"`
+	References  []*Reference   `json:"references,omitempty"`
+	SchemaId    *string        `json:"schema_id,omitempty"`
+	Status      string         `json:"status"`
+	Type        string         `json:"type"`
+	Write       []string       `json:"write,omitempty"`
+}
 
 type TicketList struct {
 	Count   int                     `json:"count"`


### PR DESCRIPTION
# Reasons
For now, a script that creates ticket have to send the value of a playbook (in encoded YAML) and the template content (in encoded JSON) on `/tickets/`.
The idea here is to use references already stored for playbooks and templates (by IDs) to avoid to have to change the values in the calling scripts.

By the way, the current implementation on the /tickets endpoint allow an analyst to change the content of a playbook that will be run on a ticket, thus an _Analyst_ role actually escalates privileges to an _Engineer_ role.

# Changes
* add a ticketbyref type
* add a tickets/byref endpoint
* modify generate.sh `sed` to be usable for linux users