### PR TITLE
Fix: Upgrade docker base image version to provide shared object dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:23.04
 
 RUN apt-get update -y && apt-get -y install curl gnupg2 software-properties-common
 RUN curl -OL https://download.arangodb.com/arangodb34/DEBIAN/Release.key


### PR DESCRIPTION
Because of issue https://github.com/SecurityBrewery/catalyst/issues/1043.
Tried the latest stable ubuntu release and did some tests where everything seemed fine, although it's hard to have this 100% tested, since the original problem is based on shared libraries and another issues that haven't been noticed could arise during runtime.

Either solved the above issue where the image couldn't even start anymore because of missing dependencies


