### PR TITLE
fix: pr lint scopes

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -18,7 +18,8 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         with:
-          disallowScopes: ".*"
-          subjectPattern: "^(?![A-Z]).+$"
+          scopes: |
+            deps
+          subjectPattern: "^(?!deps$).+"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Allow "deps" scope for Dependabot PRs.