### PR TITLE
Add collection tests for comments and tickets

### DIFF
--- a/testing/collection_comment_test.go
+++ b/testing/collection_comment_test.go
@@ -1,0 +1,237 @@
+package testing
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/SecurityBrewery/catalyst/app"
+	"github.com/SecurityBrewery/catalyst/app/database"
+	"github.com/SecurityBrewery/catalyst/app/database/sqlc"
+)
+
+func TestCommentsCollection(t *testing.T) {
+	t.Parallel()
+
+	setup := func(t *testing.T, app *app.App) {
+		_, err := app.Queries.CreateComment(context.Background(), sqlc.CreateCommentParams{
+			ID:      "c_test_comment",
+			Author:  "u_bob_analyst",
+			Message: "comment",
+			Ticket:  "test-ticket",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	testSets := []catalystTest{
+		{
+			baseTest: BaseTest{
+				Name:   "ListComments",
+				Method: http.MethodGet,
+				URL:    "/api/comments?ticket=test-ticket",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+					ExpectedEvents: map[string]int{},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedHeaders: map[string]string{
+						"X-Total-Count": "1",
+					},
+					ExpectedEvents: map[string]int{"OnRecordsListRequest": 1},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedHeaders: map[string]string{
+						"X-Total-Count": "1",
+					},
+					ExpectedEvents: map[string]int{"OnRecordsListRequest": 1},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:           "CreateComment",
+				Method:         http.MethodPost,
+				RequestHeaders: map[string]string{"Content-Type": "application/json"},
+				URL:            "/api/comments",
+				Body: s(map[string]any{
+					"author":  "u_bob_analyst",
+					"message": "new",
+					"ticket":  "test-ticket",
+				}),
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"ticket":"test-ticket"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterCreateRequest":  1,
+						"OnRecordBeforeCreateRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"ticket":"test-ticket"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterCreateRequest":  1,
+						"OnRecordBeforeCreateRequest": 1,
+					},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:   "GetComment",
+				Method: http.MethodGet,
+				URL:    "/api/comments/c_test_comment",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"c_test_comment"`,
+					},
+					ExpectedEvents: map[string]int{"OnRecordViewRequest": 1},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"c_test_comment"`,
+					},
+					ExpectedEvents: map[string]int{"OnRecordViewRequest": 1},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:           "UpdateComment",
+				Method:         http.MethodPatch,
+				RequestHeaders: map[string]string{"Content-Type": "application/json"},
+				URL:            "/api/comments/c_test_comment",
+				Body:           s(map[string]any{"message": "update"}),
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"c_test_comment"`,
+						`"message":"update"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterUpdateRequest":  1,
+						"OnRecordBeforeUpdateRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"c_test_comment"`,
+						`"message":"update"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterUpdateRequest":  1,
+						"OnRecordBeforeUpdateRequest": 1,
+					},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:   "DeleteComment",
+				Method: http.MethodDelete,
+				URL:    "/api/comments/c_test_comment",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusNoContent,
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterDeleteRequest":  1,
+						"OnRecordBeforeDeleteRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusNoContent,
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterDeleteRequest":  1,
+						"OnRecordBeforeDeleteRequest": 1,
+					},
+				},
+			},
+		},
+	}
+
+	for _, testSet := range testSets {
+		t.Run(testSet.baseTest.Name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, userTest := range testSet.userTests {
+				t.Run(userTest.Name, func(t *testing.T) {
+					t.Parallel()
+
+					runMatrixTestWithSetup(t, testSet.baseTest, userTest, setup)
+				})
+			}
+		})
+	}
+}

--- a/testing/collection_ticket_test.go
+++ b/testing/collection_ticket_test.go
@@ -1,0 +1,226 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/SecurityBrewery/catalyst/app/database"
+)
+
+func TestTicketsCollection(t *testing.T) {
+	t.Parallel()
+
+	testSets := []catalystTest{
+		{
+			baseTest: BaseTest{
+				Name:   "ListTickets",
+				Method: http.MethodGet,
+				URL:    "/api/tickets",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedHeaders: map[string]string{
+						"X-Total-Count": "1",
+					},
+					ExpectedEvents: map[string]int{"OnRecordsListRequest": 1},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedHeaders: map[string]string{
+						"X-Total-Count": "1",
+					},
+					ExpectedEvents: map[string]int{"OnRecordsListRequest": 1},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:           "CreateTicket",
+				Method:         http.MethodPost,
+				RequestHeaders: map[string]string{"Content-Type": "application/json"},
+				URL:            "/api/tickets",
+				Body: s(map[string]any{
+					"name":        "new",
+					"type":        "incident",
+					"description": "test",
+					"open":        true,
+					"owner":       "u_bob_analyst",
+					"resolution":  "",
+					"schema":      map[string]any{},
+					"state":       map[string]any{},
+				}),
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"name":"new"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterCreateRequest":  1,
+						"OnRecordBeforeCreateRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"name":"new"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterCreateRequest":  1,
+						"OnRecordBeforeCreateRequest": 1,
+					},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:   "GetTicket",
+				Method: http.MethodGet,
+				URL:    "/api/tickets/test-ticket",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"test-ticket"`,
+					},
+					ExpectedEvents: map[string]int{"OnRecordViewRequest": 1},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"test-ticket"`,
+					},
+					ExpectedEvents: map[string]int{"OnRecordViewRequest": 1},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:           "UpdateTicket",
+				Method:         http.MethodPatch,
+				RequestHeaders: map[string]string{"Content-Type": "application/json"},
+				URL:            "/api/tickets/test-ticket",
+				Body:           s(map[string]any{"name": "update"}),
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"test-ticket"`,
+						`"name":"update"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterUpdateRequest":  1,
+						"OnRecordBeforeUpdateRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"test-ticket"`,
+						`"name":"update"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterUpdateRequest":  1,
+						"OnRecordBeforeUpdateRequest": 1,
+					},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:   "DeleteTicket",
+				Method: http.MethodDelete,
+				URL:    "/api/tickets/test-ticket",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusNoContent,
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterDeleteRequest":  1,
+						"OnRecordBeforeDeleteRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusNoContent,
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterDeleteRequest":  1,
+						"OnRecordBeforeDeleteRequest": 1,
+					},
+				},
+			},
+		},
+	}
+
+	for _, testSet := range testSets {
+		t.Run(testSet.baseTest.Name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, userTest := range testSet.userTests {
+				t.Run(userTest.Name, func(t *testing.T) {
+					t.Parallel()
+
+					runMatrixTest(t, testSet.baseTest, userTest)
+				})
+			}
+		})
+	}
+}

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/SecurityBrewery/catalyst/app"
 )
 
 type BaseTest struct {
@@ -106,4 +108,71 @@ func b(data map[string]any) []byte {
 
 func s(data map[string]any) string {
 	return string(b(data))
+}
+
+func runMatrixTestWithSetup(t *testing.T, baseTest BaseTest, userTest UserTest, setup func(t *testing.T, app *app.App)) {
+	t.Helper()
+
+	baseApp, counter := App(t)
+
+	if setup != nil {
+		setup(t, baseApp)
+	}
+
+	recorder := httptest.NewRecorder()
+	body := bytes.NewBufferString(baseTest.Body)
+	req := httptest.NewRequest(baseTest.Method, baseTest.URL, body)
+
+	for k, v := range baseTest.RequestHeaders {
+		req.Header.Set(k, v)
+	}
+
+	if userTest.AuthRecord != "" {
+		user, err := baseApp.Queries.UserByEmail(t.Context(), userTest.AuthRecord)
+		require.NoError(t, err)
+
+		permissions, err := baseApp.Queries.ListUserPermissions(t.Context(), user.ID)
+		require.NoError(t, err)
+
+		loginToken, err := baseApp.Auth.CreateAccessToken(&user, permissions, time.Hour)
+		require.NoError(t, err)
+
+		req.Header.Set("Authorization", "Bearer "+loginToken)
+	}
+
+	if userTest.Admin != "" {
+		user, err := baseApp.Queries.UserByEmail(t.Context(), userTest.Admin)
+		require.NoError(t, err)
+
+		permissions, err := baseApp.Queries.ListUserPermissions(t.Context(), user.ID)
+		require.NoError(t, err)
+
+		loginToken, err := baseApp.Auth.CreateAccessToken(&user, permissions, time.Hour)
+		require.NoError(t, err)
+
+		req.Header.Set("Authorization", "Bearer "+loginToken)
+	}
+
+	baseApp.Router.ServeHTTP(recorder, req)
+
+	res := recorder.Result()
+	defer res.Body.Close()
+
+	assert.Equal(t, userTest.ExpectedStatus, res.StatusCode)
+
+	for k, v := range userTest.ExpectedHeaders {
+		assert.Equal(t, v, res.Header.Get(k))
+	}
+
+	for _, expectedContent := range userTest.ExpectedContent {
+		assert.Contains(t, recorder.Body.String(), expectedContent)
+	}
+
+	for _, notExpectedContent := range userTest.NotExpectedContent {
+		assert.NotContains(t, recorder.Body.String(), notExpectedContent)
+	}
+
+	for event, count := range userTest.ExpectedEvents {
+		assert.Equalf(t, count, counter.Count(event), "expected %d events for %s, got %d", count, event, counter.Count(event))
+	}
 }


### PR DESCRIPTION
## Summary
- add helper `runMatrixTestWithSetup`
- add collection tests for the comments and tickets APIs

## Testing
- `go test ./...` *(fails: proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68416dfee16083328d4d913d14b72aaf