### PR TITLE
test: add database collection tests

### DIFF
--- a/app/database/testdata.go
+++ b/app/database/testdata.go
@@ -19,6 +19,10 @@ func DefaultTestData(t *testing.T, queries *sqlc.Queries) {
 	userTestData(t, queries)
 	ticketTestData(t, queries)
 	reactionTestData(t, queries)
+	linkTestData(t, queries)
+	taskTestData(t, queries)
+	timelineTestData(t, queries)
+	typeTestData(t, queries)
 }
 
 func userTestData(t *testing.T, queries *sqlc.Queries) {
@@ -154,6 +158,60 @@ func reactionTestData(t *testing.T, queries *sqlc.Queries) {
 		Triggerdata: `{"collections":["tickets"],"events":["create"]}`,
 		Action:      "python",
 		Actiondata:  `{"requirements":"requests","script":"import requests\nrequests.post('http://127.0.0.1:12346/test', json={'test':True})"}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func linkTestData(t *testing.T, queries *sqlc.Queries) {
+	t.Helper()
+
+	if _, err := queries.CreateLink(t.Context(), sqlc.CreateLinkParams{
+		ID:     "l_test_link",
+		Name:   "Catalyst",
+		Url:    "https://example.com",
+		Ticket: "test-ticket",
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func taskTestData(t *testing.T, queries *sqlc.Queries) {
+	t.Helper()
+
+	if _, err := queries.CreateTask(t.Context(), sqlc.CreateTaskParams{
+		ID:     "ta_test_task",
+		Name:   "Test Task",
+		Open:   true,
+		Owner:  "u_bob_analyst",
+		Ticket: "test-ticket",
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func timelineTestData(t *testing.T, queries *sqlc.Queries) {
+	t.Helper()
+
+	if _, err := queries.CreateTimeline(t.Context(), sqlc.CreateTimelineParams{
+		ID:      "h_test_timeline",
+		Message: "Initial timeline entry.",
+		Ticket:  "test-ticket",
+		Time:    "2023-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func typeTestData(t *testing.T, queries *sqlc.Queries) {
+	t.Helper()
+
+	if _, err := queries.CreateType(t.Context(), sqlc.CreateTypeParams{
+		ID:       "test-type",
+		Singular: "Test",
+		Plural:   "Tests",
+		Icon:     "Bug",
+		Schema:   `{}`,
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/testing/collection_link_test.go
+++ b/testing/collection_link_test.go
@@ -1,0 +1,222 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/SecurityBrewery/catalyst/app/database"
+)
+
+func TestLinksCollection(t *testing.T) {
+	t.Parallel()
+
+	testSets := []catalystTest{
+		{
+			baseTest: BaseTest{
+				Name:   "ListLinks",
+				Method: http.MethodGet,
+				URL:    "/api/links?ticket=test-ticket",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+					ExpectedEvents: map[string]int{},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedHeaders: map[string]string{
+						"X-Total-Count": "1",
+					},
+					ExpectedEvents: map[string]int{},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedHeaders: map[string]string{
+						"X-Total-Count": "1",
+					},
+					ExpectedEvents: map[string]int{},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:           "CreateLink",
+				Method:         http.MethodPost,
+				RequestHeaders: map[string]string{"Content-Type": "application/json"},
+				URL:            "/api/links",
+				Body: s(map[string]any{
+					"ticket": "test-ticket",
+					"name":   "new",
+					"url":    "https://example.com/new",
+				}),
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"ticket":"test-ticket"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterCreateRequest":  1,
+						"OnRecordBeforeCreateRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"ticket":"test-ticket"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterCreateRequest":  1,
+						"OnRecordBeforeCreateRequest": 1,
+					},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:   "GetLink",
+				Method: http.MethodGet,
+				URL:    "/api/links/l_test_link",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"l_test_link"`,
+					},
+					ExpectedEvents: map[string]int{"OnRecordViewRequest": 1},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"l_test_link"`,
+					},
+					ExpectedEvents: map[string]int{"OnRecordViewRequest": 1},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:           "UpdateLink",
+				Method:         http.MethodPatch,
+				RequestHeaders: map[string]string{"Content-Type": "application/json"},
+				URL:            "/api/links/l_test_link",
+				Body:           s(map[string]any{"name": "update"}),
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"l_test_link"`,
+						`"name":"update"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterUpdateRequest":  1,
+						"OnRecordBeforeUpdateRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"l_test_link"`,
+						`"name":"update"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterUpdateRequest":  1,
+						"OnRecordBeforeUpdateRequest": 1,
+					},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:   "DeleteLink",
+				Method: http.MethodDelete,
+				URL:    "/api/links/l_test_link",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusNoContent,
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterDeleteRequest":  1,
+						"OnRecordBeforeDeleteRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusNoContent,
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterDeleteRequest":  1,
+						"OnRecordBeforeDeleteRequest": 1,
+					},
+				},
+			},
+		},
+	}
+
+	for _, testSet := range testSets {
+		t.Run(testSet.baseTest.Name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, userTest := range testSet.userTests {
+				t.Run(userTest.Name, func(t *testing.T) {
+					t.Parallel()
+
+					runMatrixTest(t, testSet.baseTest, userTest)
+				})
+			}
+		})
+	}
+}

--- a/testing/collection_task_test.go
+++ b/testing/collection_task_test.go
@@ -1,0 +1,223 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/SecurityBrewery/catalyst/app/database"
+)
+
+func TestTasksCollection(t *testing.T) {
+	t.Parallel()
+
+	testSets := []catalystTest{
+		{
+			baseTest: BaseTest{
+				Name:   "ListTasks",
+				Method: http.MethodGet,
+				URL:    "/api/tasks?ticket=test-ticket",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+					ExpectedEvents: map[string]int{},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedHeaders: map[string]string{
+						"X-Total-Count": "1",
+					},
+					ExpectedEvents: map[string]int{"OnRecordsListRequest": 1},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedHeaders: map[string]string{
+						"X-Total-Count": "1",
+					},
+					ExpectedEvents: map[string]int{"OnRecordsListRequest": 1},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:           "CreateTask",
+				Method:         http.MethodPost,
+				RequestHeaders: map[string]string{"Content-Type": "application/json"},
+				URL:            "/api/tasks",
+				Body: s(map[string]any{
+					"ticket": "test-ticket",
+					"name":   "new",
+					"open":   true,
+					"owner":  "u_bob_analyst",
+				}),
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"ticket":"test-ticket"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterCreateRequest":  1,
+						"OnRecordBeforeCreateRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"ticket":"test-ticket"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterCreateRequest":  1,
+						"OnRecordBeforeCreateRequest": 1,
+					},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:   "GetTask",
+				Method: http.MethodGet,
+				URL:    "/api/tasks/ta_test_task",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"ta_test_task"`,
+					},
+					ExpectedEvents: map[string]int{"OnRecordViewRequest": 1},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"ta_test_task"`,
+					},
+					ExpectedEvents: map[string]int{"OnRecordViewRequest": 1},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:           "UpdateTask",
+				Method:         http.MethodPatch,
+				RequestHeaders: map[string]string{"Content-Type": "application/json"},
+				URL:            "/api/tasks/ta_test_task",
+				Body:           s(map[string]any{"name": "update"}),
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"ta_test_task"`,
+						`"name":"update"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterUpdateRequest":  1,
+						"OnRecordBeforeUpdateRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"ta_test_task"`,
+						`"name":"update"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterUpdateRequest":  1,
+						"OnRecordBeforeUpdateRequest": 1,
+					},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:   "DeleteTask",
+				Method: http.MethodDelete,
+				URL:    "/api/tasks/ta_test_task",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusNoContent,
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterDeleteRequest":  1,
+						"OnRecordBeforeDeleteRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusNoContent,
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterDeleteRequest":  1,
+						"OnRecordBeforeDeleteRequest": 1,
+					},
+				},
+			},
+		},
+	}
+
+	for _, testSet := range testSets {
+		t.Run(testSet.baseTest.Name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, userTest := range testSet.userTests {
+				t.Run(userTest.Name, func(t *testing.T) {
+					t.Parallel()
+
+					runMatrixTest(t, testSet.baseTest, userTest)
+				})
+			}
+		})
+	}
+}

--- a/testing/collection_timeline_test.go
+++ b/testing/collection_timeline_test.go
@@ -1,0 +1,222 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/SecurityBrewery/catalyst/app/database"
+)
+
+func TestTimelineCollection(t *testing.T) {
+	t.Parallel()
+
+	testSets := []catalystTest{
+		{
+			baseTest: BaseTest{
+				Name:   "ListTimeline",
+				Method: http.MethodGet,
+				URL:    "/api/timeline?ticket=test-ticket",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+					ExpectedEvents: map[string]int{},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedHeaders: map[string]string{
+						"X-Total-Count": "1",
+					},
+					ExpectedEvents: map[string]int{"OnRecordsListRequest": 1},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedHeaders: map[string]string{
+						"X-Total-Count": "1",
+					},
+					ExpectedEvents: map[string]int{"OnRecordsListRequest": 1},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:           "CreateTimeline",
+				Method:         http.MethodPost,
+				RequestHeaders: map[string]string{"Content-Type": "application/json"},
+				URL:            "/api/timeline",
+				Body: s(map[string]any{
+					"ticket":  "test-ticket",
+					"message": "new",
+					"time":    "2023-01-01T00:00:00Z",
+				}),
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"ticket":"test-ticket"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterCreateRequest":  1,
+						"OnRecordBeforeCreateRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"ticket":"test-ticket"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterCreateRequest":  1,
+						"OnRecordBeforeCreateRequest": 1,
+					},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:   "GetTimeline",
+				Method: http.MethodGet,
+				URL:    "/api/timeline/h_test_timeline",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"h_test_timeline"`,
+					},
+					ExpectedEvents: map[string]int{"OnRecordViewRequest": 1},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"h_test_timeline"`,
+					},
+					ExpectedEvents: map[string]int{"OnRecordViewRequest": 1},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:           "UpdateTimeline",
+				Method:         http.MethodPatch,
+				RequestHeaders: map[string]string{"Content-Type": "application/json"},
+				URL:            "/api/timeline/h_test_timeline",
+				Body:           s(map[string]any{"message": "update"}),
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"h_test_timeline"`,
+						`"message":"update"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterUpdateRequest":  1,
+						"OnRecordBeforeUpdateRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"h_test_timeline"`,
+						`"message":"update"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterUpdateRequest":  1,
+						"OnRecordBeforeUpdateRequest": 1,
+					},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:   "DeleteTimeline",
+				Method: http.MethodDelete,
+				URL:    "/api/timeline/h_test_timeline",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusNoContent,
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterDeleteRequest":  1,
+						"OnRecordBeforeDeleteRequest": 1,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusNoContent,
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterDeleteRequest":  1,
+						"OnRecordBeforeDeleteRequest": 1,
+					},
+				},
+			},
+		},
+	}
+
+	for _, testSet := range testSets {
+		t.Run(testSet.baseTest.Name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, userTest := range testSet.userTests {
+				t.Run(userTest.Name, func(t *testing.T) {
+					t.Parallel()
+
+					runMatrixTest(t, testSet.baseTest, userTest)
+				})
+			}
+		})
+	}
+}

--- a/testing/collection_type_test.go
+++ b/testing/collection_type_test.go
@@ -1,0 +1,213 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/SecurityBrewery/catalyst/app/database"
+)
+
+func TestTypesCollection(t *testing.T) {
+	t.Parallel()
+
+	testSets := []catalystTest{
+		{
+			baseTest: BaseTest{
+				Name:   "ListTypes",
+				Method: http.MethodGet,
+				URL:    "/api/types",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+					ExpectedEvents: map[string]int{},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedHeaders: map[string]string{
+						"X-Total-Count": "4",
+					},
+					ExpectedEvents: map[string]int{"OnRecordsListRequest": 1},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedHeaders: map[string]string{
+						"X-Total-Count": "4",
+					},
+					ExpectedEvents: map[string]int{"OnRecordsListRequest": 1},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:           "CreateType",
+				Method:         http.MethodPost,
+				RequestHeaders: map[string]string{"Content-Type": "application/json"},
+				URL:            "/api/types",
+				Body: s(map[string]any{
+					"singular": "Example",
+					"plural":   "Examples",
+					"icon":     "Bug",
+					"schema":   map[string]any{},
+				}),
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"missing required scopes"`,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"singular":"Example"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterCreateRequest":  1,
+						"OnRecordBeforeCreateRequest": 1,
+					},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:   "GetType",
+				Method: http.MethodGet,
+				URL:    "/api/types/test-type",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"test-type"`,
+					},
+					ExpectedEvents: map[string]int{"OnRecordViewRequest": 1},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"test-type"`,
+					},
+					ExpectedEvents: map[string]int{"OnRecordViewRequest": 1},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:           "UpdateType",
+				Method:         http.MethodPatch,
+				RequestHeaders: map[string]string{"Content-Type": "application/json"},
+				URL:            "/api/types/test-type",
+				Body:           s(map[string]any{"singular": "Update"}),
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"missing required scopes"`,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusOK,
+					ExpectedContent: []string{
+						`"id":"test-type"`,
+						`"singular":"Update"`,
+					},
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterUpdateRequest":  1,
+						"OnRecordBeforeUpdateRequest": 1,
+					},
+				},
+			},
+		},
+		{
+			baseTest: BaseTest{
+				Name:   "DeleteType",
+				Method: http.MethodDelete,
+				URL:    "/api/types/test-type",
+			},
+			userTests: []UserTest{
+				{
+					Name:           "Unauthorized",
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"invalid bearer token"`,
+					},
+				},
+				{
+					Name:           "Analyst",
+					AuthRecord:     database.AnalystEmail,
+					ExpectedStatus: http.StatusUnauthorized,
+					ExpectedContent: []string{
+						`"missing required scopes"`,
+					},
+				},
+				{
+					Name:           "Admin",
+					Admin:          database.AdminEmail,
+					ExpectedStatus: http.StatusNoContent,
+					ExpectedEvents: map[string]int{
+						"OnRecordAfterDeleteRequest":  1,
+						"OnRecordBeforeDeleteRequest": 1,
+					},
+				},
+			},
+		},
+	}
+
+	for _, testSet := range testSets {
+		t.Run(testSet.baseTest.Name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, userTest := range testSet.userTests {
+				t.Run(userTest.Name, func(t *testing.T) {
+					t.Parallel()
+
+					runMatrixTest(t, testSet.baseTest, userTest)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add test data for links, tasks, timeline, and types
- create collection tests for links, tasks, timeline and types

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6841c6cfa6bc8332bddabd7911e838fa