### PR TITLE
chore: remove admin interface link from dashboard cards

### DIFF
--- a/ui/src/views/DashboardView.vue
+++ b/ui/src/views/DashboardView.vue
@@ -58,14 +58,6 @@ const count = (id: string) => {
               Open Catalyst Handbook
               <ExternalLink class="ml-2 h-4 w-4" />
             </a>
-            <a
-              href="/_/"
-              target="_blank"
-              class="flex items-center rounded border p-2 text-blue-500 hover:bg-accent"
-            >
-              Open Admin Interface
-              <ExternalLink class="ml-2 h-4 w-4" />
-            </a>
           </CardContent>
         </Card>
         <Card>
@@ -116,14 +108,6 @@ const count = (id: string) => {
               class="flex items-center rounded border p-2 text-blue-500 hover:bg-accent"
             >
               Open Catalyst Handbook
-              <ExternalLink class="ml-2 h-4 w-4" />
-            </a>
-            <a
-              href="/_/"
-              target="_blank"
-              class="flex items-center rounded border p-2 text-blue-500 hover:bg-accent"
-            >
-              Open Admin Interface
               <ExternalLink class="ml-2 h-4 w-4" />
             </a>
           </CardContent>


### PR DESCRIPTION
## Summary
- remove the "Open Admin Interface" anchors from the Catalyst cards on the dashboard so the shortcut is no longer displayed

## Testing
- npm run build *(fails: existing TypeScript errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d01216ee5c8332ade3ac5a56e74bdc