### PR TITLE
refactor: sanitize webhook auth payload

### DIFF
--- a/app/reaction/trigger/hook/hook.go
+++ b/app/reaction/trigger/hook/hook.go
@@ -60,7 +60,7 @@ func runHook(ctx context.Context, queries *sqlc.Queries, collection, event strin
 		Action:     event,
 		Collection: collection,
 		Record:     record,
-		Auth:       auth,
+		Auth:       webhook.SanitizeUser(auth),
 		Admin:      nil,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- introduce a sanitized auth user representation for webhook payloads so password and token fields are omitted
- update webhook and hook trigger payloads to use the sanitized auth data before sending

## Testing
- go test ./... *(hangs, aborted)*
- go test ./app/webhook ./app/reaction/trigger/hook *(hangs, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d0124cceb883328f56197951052275